### PR TITLE
[TTK] remove compilation warnings

### DIFF
--- a/Algorithms/itkCrossingTensorImageSource.txx
+++ b/Algorithms/itkCrossingTensorImageSource.txx
@@ -38,9 +38,10 @@ namespace itk
     typename TensorImageType::SizeType size = {{0}};
 
     typename TensorImageType::SizeType::SizeValueType localSize[NDimensions];
-    for (int i=0; i<NDimensions; ++i)
+    for (unsigned int i=0; i<NDimensions; ++i)
+    {
         localSize[i]  = m_Size[i];
-
+    }
     size.SetSize( localSize );
     
     RegionType region;

--- a/Algorithms/itkDTIEstimatorTensorImageFilter.txx
+++ b/Algorithms/itkDTIEstimatorTensorImageFilter.txx
@@ -79,8 +79,6 @@ namespace itk
     typedef ImageRegionIterator<OutputImageType>      IteratorOutputType;
     typedef ImageRegionConstIterator<InputImageType>  IteratorInputType;
 
-    unsigned long numPixels = outputRegionForThread.GetNumberOfPixels();
-    unsigned long step = numPixels/1000;
     unsigned long progress = 0;
     
     int n = (int)(this->GetNumberOfIndexedInputs());

--- a/Algorithms/itkDTIEstimatorWithBFGSTensorImageFilter.txx
+++ b/Algorithms/itkDTIEstimatorWithBFGSTensorImageFilter.txx
@@ -371,9 +371,8 @@ namespace itk
     ScalarType EPS = 1e-12;
 
     OutputPixelType junk;
-    ScalarType Et = Simulator (data, L+DIR*t, junk);
     
-    while( /*isnan ( Et ) &*/ t>EPS )
+    while( t>EPS )
     {      
       t *= 0.5;
       Et = Simulator (data, L+DIR*t, junk);
@@ -634,15 +633,7 @@ namespace itk
         InternalMatrixType Wt (6,6);
         Wt.set_identity();
 
-
         OutputPixelType GRADt;
-        ScalarType Et = this->Simulator(data, Lt, GRADt);
-        
-
-	/*
-        if ( isnan ( Et ) )
-          Lt = OutputPixelType( static_cast<ScalarType>( 0.0 ) );
-	*/
         
         unsigned int nite = 0;
         ScalarType Energy = 9999999;

--- a/Algorithms/itkDTIEstimatorWithBFGSTensorImageFilter.txx
+++ b/Algorithms/itkDTIEstimatorWithBFGSTensorImageFilter.txx
@@ -369,13 +369,10 @@ namespace itk
     
     ScalarType t = m_Tinit;
     ScalarType EPS = 1e-12;
-
-    OutputPixelType junk;
     
     while( t>EPS )
     {      
       t *= 0.5;
-      Et = Simulator (data, L+DIR*t, junk);
     }        
     
     ScalarType tg = 0.0;
@@ -680,24 +677,16 @@ namespace itk
 
           // nouveau gradient
           OutputPixelType GRADtt;
-          ScalarType Ett = this->Simulator (data, Ltt, GRADtt);
+          Simulator (data, Ltt, GRADtt);
 
           // nouvelle matrice BFGS
           Wt = this->BFGS(Lt,Ltt,GRADt,GRADtt,Wt);
 
           GRADt = GRADtt;
 
-          //Energy = (Lt - Ltt).GetNorm();/*Et-Ett;*/ //GRADt.GetNorm();
           Energy = GRADt.GetNorm();
-		  
-/*
-		  if ( isnan (Energy) )          
-          {
-            break;            
-          }
-  */        
+ 
           Lt = Ltt;
-          Et = Ett;
    
           nite++;          
           

--- a/Algorithms/itkFiberImageToVtkPolyData.txx
+++ b/Algorithms/itkFiberImageToVtkPolyData.txx
@@ -90,6 +90,7 @@ namespace itk
     unsigned long numPixels = this->GetInput()->GetLargestPossibleRegion().GetNumberOfPixels();
     unsigned long step      = numPixels/10;
     unsigned long progress  = 0;
+    TensorType t;
 
     this->UpdateProgress (0.0);
 
@@ -108,7 +109,7 @@ namespace itk
         diff /= diff.GetNorm();
 
         double fa = 0.0;
-        TensorType t = listPoints[0].Tensor;
+        t = listPoints[0].Tensor;
         if (!t.IsZero())
         {
           fa = t.GetFA();
@@ -136,11 +137,8 @@ namespace itk
         {
           for( int i=1; i<npts-1; i++)
           {
-//            PointType point = listPoints[i].Point;
-
-            //alpha = 1.0;
             fa = 0.0;
-            TensorType t = listPoints[i].Tensor;
+            t = listPoints[i].Tensor;
             if (!t.IsZero())
             {
               fa = t.GetFA();
@@ -170,7 +168,7 @@ namespace itk
 
           fa = 0.0;
           //double alpha = 1.0;
-          TensorType t = listPoints[npts-1].Tensor;
+          t = listPoints[npts-1].Tensor;
           if (!t.IsZero())
           {
             fa = t.GetFA();

--- a/Algorithms/itkFiberTrackingImageFilter.txx
+++ b/Algorithms/itkFiberTrackingImageFilter.txx
@@ -127,7 +127,6 @@ void
 FiberTrackingImageFilter< TInputImage, TOutputImage >
 ::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegion)
 {
-    typedef ZeroFluxNeumannBoundaryCondition<TOutputImage>                   BoundaryConditionType;
     typedef ImageRegionConstIteratorWithIndex<InputImageType>                InputIteratorType;
     typedef ImageRegionIteratorWithIndex<OutputImageType>                    IteratorType;
     typedef ImageRegionIteratorWithIndex<ImageType>                          ImageIteratorType;

--- a/Algorithms/itkFiberTrackingImageFilter.txx
+++ b/Algorithms/itkFiberTrackingImageFilter.txx
@@ -128,7 +128,6 @@ FiberTrackingImageFilter< TInputImage, TOutputImage >
 ::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegion)
 {
     typedef ZeroFluxNeumannBoundaryCondition<TOutputImage>                   BoundaryConditionType;
-    typedef ConstNeighborhoodIterator<InputImageType,BoundaryConditionType>  NIType;
     typedef ImageRegionConstIteratorWithIndex<InputImageType>                InputIteratorType;
     typedef ImageRegionIteratorWithIndex<OutputImageType>                    IteratorType;
     typedef ImageRegionIteratorWithIndex<ImageType>                          ImageIteratorType;

--- a/Algorithms/itkFlipTensorImageFilter.h
+++ b/Algorithms/itkFlipTensorImageFilter.h
@@ -68,9 +68,12 @@ namespace itk
     /** Set (to 1) here the axes to be flipped 
         Note that axes array size must be ImageDimension */
     void SetFlipAxes (const bool* axes)
-    { for (unsigned int i=0;i<ImageDimension;i++)
+    { 
+      for (unsigned int i=0;i<ImageDimension;i++)
+      {
         m_FlipAxes[i] = axes[i];
-        this->Modified();
+      }
+      this->Modified();
     }
     /** Set here weither an axis has
         to be flipped or not */

--- a/Algorithms/itkFlipTensorImageFilter.txx
+++ b/Algorithms/itkFlipTensorImageFilter.txx
@@ -59,9 +59,6 @@ namespace itk
     
     InputIteratorType itIn(this->GetInput(), outputRegionForThread);
     OutputIteratorType itOut(this->GetOutput(), outputRegionForThread);
-    
-    unsigned long numPixels = outputRegionForThread.GetNumberOfPixels();
-    unsigned long step = numPixels/1000;
 
     while ( ! itOut.IsAtEnd() )
     {

--- a/Algorithms/itkProlateSheetTrackingImageFilter.txx
+++ b/Algorithms/itkProlateSheetTrackingImageFilter.txx
@@ -179,7 +179,6 @@ ProlateSheetTrackingImageFilter< TInputImage, TOutputImage >
 ::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegion)
 {
     typedef ZeroFluxNeumannBoundaryCondition<TOutputImage>                   BoundaryConditionType;
-    typedef ConstNeighborhoodIterator<InputImageType,BoundaryConditionType>  NIType;
     typedef ImageRegionConstIteratorWithIndex<InputImageType>                InputIteratorType;
     typedef ImageRegionIteratorWithIndex<OutputImageType>                    IteratorType;
     typedef ImageRegionIteratorWithIndex<ImageType>                          ImageIteratorType;

--- a/Algorithms/itkProlateSheetTrackingImageFilter.txx
+++ b/Algorithms/itkProlateSheetTrackingImageFilter.txx
@@ -178,7 +178,6 @@ void
 ProlateSheetTrackingImageFilter< TInputImage, TOutputImage >
 ::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegion)
 {
-    typedef ZeroFluxNeumannBoundaryCondition<TOutputImage>                   BoundaryConditionType;
     typedef ImageRegionConstIteratorWithIndex<InputImageType>                InputIteratorType;
     typedef ImageRegionIteratorWithIndex<OutputImageType>                    IteratorType;
     typedef ImageRegionIteratorWithIndex<ImageType>                          ImageIteratorType;

--- a/Algorithms/itkRemoveNonPositiveTensorsTensorImageFilter.txx
+++ b/Algorithms/itkRemoveNonPositiveTensorsTensorImageFilter.txx
@@ -104,8 +104,6 @@ namespace itk
     typename OutputImageType::Pointer       output = this->GetOutput();
     typename InputImageType::ConstPointer   input  = this->GetInput();
 
-    unsigned long numPixels = outputRegionForThread.GetNumberOfPixels();
-    unsigned long step = numPixels/100;
     unsigned long progress = 0;
 
     // Find the data-set boundary "faces"

--- a/Algorithms/itkResampleTensorImageFilter.txx
+++ b/Algorithms/itkResampleTensorImageFilter.txx
@@ -266,7 +266,7 @@ namespace itk
       // Therefore, the following routine uses a
       // precisionConstant that specifies the number of relevant bits,
       // and the value is truncated to this precision.
-      for (int i=0; i < ImageDimension; ++i)
+      for (unsigned int i=0; i < ImageDimension; ++i)
       {
         double roundedInputIndex = std::floor(inputIndex[i]);
         double inputIndexFrac    = inputIndex[i] - roundedInputIndex;
@@ -284,7 +284,7 @@ namespace itk
 	
         value = m_TensorTransform->TransformTensorReverse (value);
 
-	value.SetVnlMatrix(value.ApplyMatrix (this->GetOutput()->GetDirection().GetTranspose()));
+	value.SetVnlMatrix(value.ApplyMatrix (this->GetOutput()->GetDirection().GetTranspose().as_ref()).as_ref());
 	
         pixval = static_cast<PixelType>( value );
     
@@ -409,7 +409,7 @@ namespace itk
     // Therefore, the following routine uses a
     // precisionConstant that specifies the number of relevant bits,
     // and the value is truncated to this precision.
-    for (int i=0; i < ImageDimension; ++i)
+    for (unsigned int i=0; i < ImageDimension; ++i)
     {
       double roundedDelta = std::floor(delta[i]);
       double deltaFrac = delta[i] - roundedDelta;
@@ -443,7 +443,7 @@ namespace itk
       // Therefore, the following routine uses a
       // precisionConstant that specifies the number of relevant bits,
       // and the value is truncated to this precision.
-      for (int i=0; i < ImageDimension; ++i)
+      for (unsigned int i=0; i < ImageDimension; ++i)
       {
         double roundedInputIndex = std::floor(inputIndex[i]);
         double inputIndexFrac = inputIndex[i] - roundedInputIndex;
@@ -464,7 +464,7 @@ namespace itk
 	  
 	  value = m_TensorTransform->TransformTensor (value);
 	  
-	  value.SetVnlMatrix(value.ApplyMatrix (this->GetOutput()->GetDirection().GetTranspose()));
+	  value.SetVnlMatrix(value.ApplyMatrix (this->GetOutput()->GetDirection().GetTranspose().as_ref()).as_ref());
 	  
           pixval = static_cast<PixelType>( value );
           outIt.Set( pixval );      

--- a/Algorithms/itkSheetImageToVtkPolyData.txx
+++ b/Algorithms/itkSheetImageToVtkPolyData.txx
@@ -90,6 +90,7 @@ namespace itk
     unsigned long numPixels = this->GetInput()->GetLargestPossibleRegion().GetNumberOfPixels();
     unsigned long step      = numPixels/10;
     unsigned long progress  = 0;
+    TensorType t;
 
     this->UpdateProgress (0.0);
 
@@ -108,7 +109,7 @@ namespace itk
         diff /= diff.GetNorm();
 	
         double fa = 0.0;
-        TensorType t = listPoints[0].Tensor;
+        t = listPoints[0].Tensor;
         if (!t.IsZero())
         {
           fa = t.GetFA();
@@ -136,9 +137,8 @@ namespace itk
         {
           for( int i=1; i<npts-1; i++)
           {            
-            //alpha = 1.0;
             fa = 0.0;
-            TensorType t = listPoints[i].Tensor;
+            t = listPoints[i].Tensor;
             if (!t.IsZero())
             {
               fa = t.GetFA();
@@ -167,8 +167,7 @@ namespace itk
           // special case of the last point
           
           fa = 0.0;
-          //double alpha = 1.0;
-          TensorType t = listPoints[npts-1].Tensor;
+          t = listPoints[npts-1].Tensor;
           if (!t.IsZero())
           {
             fa = t.GetFA();

--- a/Algorithms/itkTensorToScalarTensorImageFilter.txx
+++ b/Algorithms/itkTensorToScalarTensorImageFilter.txx
@@ -52,7 +52,6 @@ namespace itk
     typedef ImageRegionIterator<OutputImageType>      IteratorOutputType;
     typedef ImageRegionConstIterator<InputImageType>  IteratorInputType;
 
-    unsigned long numPixels = outputRegionForThread.GetNumberOfPixels();
     unsigned long progress = 0;
 	
     IteratorOutputType itOut(this->GetOutput(), outputRegionForThread);

--- a/Algorithms/itkTensorsToDWITensorImageFilter.txx
+++ b/Algorithms/itkTensorsToDWITensorImageFilter.txx
@@ -57,9 +57,6 @@ namespace itk
     typedef ImageRegionIterator<OutputImageType>      IteratorOutputType;
     typedef ImageRegionConstIterator<InputImageType>  IteratorInputType;
     
-    unsigned long numPixels = outputRegionForThread.GetNumberOfPixels();
-    unsigned long step = numPixels/100;
-    
     unsigned int NOutput = this->GetNumberOfRequiredOutputs();
         
     std::vector<IteratorOutputType> IteratorOutputList;

--- a/Algorithms/itkWarpJacobianFilter.txx
+++ b/Algorithms/itkWarpJacobianFilter.txx
@@ -233,34 +233,8 @@ WarpJacobianFilter<TInputImage, TOutputImage>
          // add one on the diagonal to consider the warping and not only the deformation field
          J[i][i] += 1.0;
       }
-
-      typename TInputImage::DirectionType direction = this->GetInput()->GetDirection();
-
-      /*
-	OutputPixelType orientedJ;
-	orientedJ.Fill (0.0);
-	orientedJ = direction * J * direction;
-	
-	for (i = 0; i < VectorDimension; ++i)
-	{
-	VectorType vec;
-	for (j=0; j<ImageDimension; j++)
-	{
-	vec[j] = J[j][i];
-	}
-	//const InputImage *input = this->GetInput();
-	this->GetInput()->TransformLocalVectorToPhysicalVector (vec, vec);
-	for (j=0; j<ImageDimension; j++)
-	{
-	orientedJ[j][i] = vec[j];
-	}
-	}
-	return orientedJ;
-      */
       
       return J;
-  
-
 }
 
 

--- a/Commands/itkAddGaussianNoiseToDWICommand.cxx
+++ b/Commands/itkAddGaussianNoiseToDWICommand.cxx
@@ -90,7 +90,6 @@ namespace itk
     typedef itk::RemoveNonPositiveTensorsTensorImageFilter<TensorImageType,TensorImageType> RemoveNPTFilterType;
 
     typedef itk::TensorsToDWITensorImageFilter<TensorImageType, ImageType>   TensorsToDWIFilter;
-    typedef TensorsToDWIFilter::GradientType                                 GradientType;
     typedef TensorsToDWIFilter::GradientListType                             GradientListType;
 
     std::cout<<"reading "<<fileIn<<"..."<<std::flush;

--- a/Commands/itkAddGaussianNoiseToDWICommand.cxx
+++ b/Commands/itkAddGaussianNoiseToDWICommand.cxx
@@ -86,7 +86,6 @@ namespace itk
     typedef itk::TensorToScalarTensorImageFilter<TensorImageType, ImageType> TensorToScalarFilterType;
     typedef itk::TensorToL2NormFunction<TensorType, ScalarType>              TensorFunctionType;
     typedef itk::DTIEstimatorTensorImageFilter<ImageType, TensorImageType>   EstimatorType;
-    typedef EstimatorType::GradientType                                      GradientType;
     typedef itk::RemoveNonPositiveTensorsTensorImageFilter<TensorImageType,TensorImageType> RemoveNPTFilterType;
 
     typedef itk::TensorsToDWITensorImageFilter<TensorImageType, ImageType>   TensorsToDWIFilter;

--- a/Commands/itkBoostTensorAnisotropyCommand.cxx
+++ b/Commands/itkBoostTensorAnisotropyCommand.cxx
@@ -123,11 +123,15 @@ namespace itk
       D[2][2] = pix.GetEigenvalue (2) * (ratio);
       
       for (unsigned int i=0; i<3; i++)
-	for (unsigned int j=0; j<3; j++)
-	  U[i][j] = pix.GetEigenvector (j)[i];
+      {
+	      for (unsigned int j=0; j<3; j++)
+        {
+	        U[i][j] = pix.GetEigenvector (j)[i];
+        }
+      }
       
-        TensorImageType::PixelType::MatrixType updatedTensor = U * D * U.GetTranspose();
-      pix.SetVnlMatrix (updatedTensor.GetVnlMatrix());
+      TensorImageType::PixelType::MatrixType updatedTensor = U * D * U.GetTranspose();
+      pix.SetVnlMatrix (updatedTensor.GetVnlMatrix().as_ref());
       
       itOut.Set ( pix );
       ++itIn;

--- a/Commands/itkDTIEstimatorCommand.cxx
+++ b/Commands/itkDTIEstimatorCommand.cxx
@@ -40,8 +40,6 @@ namespace itk
         typedef itk::RemoveNonPositiveTensorsTensorImageFilter<TensorImageType,TensorImageType>
                 RemoveNPTFilterType;
 
-        typedef itk::ImageRegionIterator<Image4DType> Iterator4DType;
-
         const char *fileIn = arg.input;
         const char *fileOut = arg.output;
         const char *fileGrad = arg.gradients;

--- a/Commands/itkDTIEstimatorCommand.cxx
+++ b/Commands/itkDTIEstimatorCommand.cxx
@@ -33,22 +33,14 @@ namespace itk
         typedef itk::TensorImageIO<float, 3, 3>            IOType;
         typedef typename IOType::TensorImageType           TensorImageType;
         typedef itk::ImageFileReader<ImageType>            ReaderType;
-        typedef itk::ImageFileReader<Image4DType>          Reader4DType;
 
         typedef itk::DTIEstimatorTensorImageFilter<ImageType, TensorImageType>
                 EstimatorType;
         typedef typename EstimatorType::GradientType GradientType;
-        typedef typename EstimatorType::GradientListType GradientListType;
         typedef itk::RemoveNonPositiveTensorsTensorImageFilter<TensorImageType,TensorImageType>
                 RemoveNPTFilterType;
 
-        typedef typename Image4DType::RegionType  Region4dType;
-        typedef typename Image4DType::SpacingType Spacing4Dtype;
-
         typedef itk::ImageRegionIterator<Image4DType> Iterator4DType;
-        typedef typename Iterator4DType::IndexType Index4DType;
-        typedef typename ImageType::DirectionType Direction3Dtype;
-        typedef typename Image4DType::DirectionType Direction4Dtype;
 
         const char *fileIn = arg.input;
         const char *fileOut = arg.output;

--- a/Commands/itkDTIEstimatorWithBFGSCommand.cxx
+++ b/Commands/itkDTIEstimatorWithBFGSCommand.cxx
@@ -85,11 +85,8 @@ namespace itk
 
     typedef double                                          ScalarType;  
     typedef itk::Image<ScalarType,3>                        ImageType;
-    typedef ImageType::RegionType                           RegionType;
-    typedef ImageType::SizeType                             SizeType;
     typedef itk::TensorImageIO<ScalarType, 3, 3>            IOType;
-    typedef IOType::TensorImageType                         TensorImageType;    
-    typedef TensorImageType::PixelType                      TensorType;
+    typedef IOType::TensorImageType                         TensorImageType;
     typedef itk::ImageFileReader<ImageType>                 ReaderType;
     typedef itk::DTIEstimatorWithBFGSTensorImageFilter<ImageType, TensorImageType>
       EstimatorType;

--- a/Commands/itkFiberTrackingCommand.cxx
+++ b/Commands/itkFiberTrackingCommand.cxx
@@ -85,7 +85,6 @@ namespace itk
     typedef float                                 ScalarType;
     typedef itk::TensorImageIO<ScalarType, 3 ,3>  IOType;
     typedef IOType::TensorImageType               TensorImageType;
-    typedef TensorImageType::PixelType            TensorType;
     typedef itk::Fiber<ScalarType, 3>             FiberType;
     typedef itk::Image<FiberType, 3>              FiberImageType;
     typedef itk::Image<unsigned char, 3>          ImageType;

--- a/Commands/itkSheetTrackingCommand.cxx
+++ b/Commands/itkSheetTrackingCommand.cxx
@@ -92,7 +92,6 @@ namespace itk
     typedef float                                 ScalarType;
     typedef itk::TensorImageIO<ScalarType, 3 ,3>  IOType;
     typedef IOType::TensorImageType               TensorImageType;
-    typedef TensorImageType::PixelType            TensorType;
     typedef itk::Sheet<ScalarType, 3>             SheetType;
     typedef itk::Image<SheetType, 3>              SheetImageType;
     typedef itk::Image<unsigned int, 3>          ImageType;

--- a/Common/itkDenseFiniteDifferenceImageFilter2.txx
+++ b/Common/itkDenseFiniteDifferenceImageFilter2.txx
@@ -233,11 +233,7 @@ DenseFiniteDifferenceImageFilter2<TInputImage, TOutputImage>::TimeStepType
 DenseFiniteDifferenceImageFilter2<TInputImage, TOutputImage>
 ::ThreadedCalculateChange(const ThreadRegionType &regionToProcess, ThreadIdType)
 {
-  typedef typename OutputImageType::RegionType RegionType;
   typedef typename OutputImageType::SizeType   SizeType;
-  typedef typename OutputImageType::SizeValueType   SizeValueType;
-  typedef typename OutputImageType::IndexType  IndexType;
-  typedef typename OutputImageType::IndexValueType  IndexValueType;
   typedef typename FiniteDifferenceFunctionType::NeighborhoodType
     NeighborhoodIteratorType;
   typedef ImageRegionIterator<UpdateBufferType> UpdateIteratorType;

--- a/Common/itkMatrixOffsetTensorTransformBase.txx
+++ b/Common/itkMatrixOffsetTensorTransformBase.txx
@@ -294,7 +294,7 @@ namespace itk
   {
     // rotate w.r.t the rigid part of the transform
     OutputTensorType TENS;
-    TENS.SetVnlMatrix ( tensor.ApplyMatrix ( m_Rigid.GetTranspose() ) );
+    TENS.SetVnlMatrix ( tensor.ApplyMatrix ( m_Rigid.GetTranspose().as_ref() ).as_ref() );
     return TENS;    
   }
   
@@ -309,7 +309,7 @@ namespace itk
   {
     // rotate w.r.t the rigid part of the transform
     OutputTensorType TENS;
-    TENS.SetVnlMatrix ( tensor.ApplyMatrix ( m_Rigid.GetVnlMatrix() ) );
+    TENS.SetVnlMatrix ( tensor.ApplyMatrix ( m_Rigid.GetVnlMatrix().as_ref() ).as_ref() );
     return TENS;    
   }
 
@@ -323,7 +323,7 @@ namespace itk
   {
     // rotate w.r.t the rigid part of the transform
     OutputTensorType TENS;
-    TENS.SetVnlMatrix ( tensor.ApplyMatrix ( m_Rigid.GetTranspose() ) );
+    TENS.SetVnlMatrix ( tensor.ApplyMatrix ( m_Rigid.GetTranspose().as_ref() ).as_ref() );
     return TENS;
   }
 
@@ -663,15 +663,11 @@ namespace itk
 
     vnl_matrix_fixed <TScalarType, NInputDimensions, NInputDimensions >
       MMt = m_Matrix.GetVnlMatrix() * m_Matrix.GetTranspose();
-
-    //std::cout << MMt << std::endl;
     
     InputTensorType T;
-    T.SetVnlMatrix (MMt);
+    T.SetVnlMatrix (MMt.as_ref());
 
     T = T.InvSqrt();
-
-    //std::cout << T << std::endl;
 
     vnl_matrix<TScalarType> res = T.GetVnlMatrix()*m_Matrix.GetVnlMatrix();
 

--- a/Common/itkTensor.txx
+++ b/Common/itkTensor.txx
@@ -1102,7 +1102,7 @@ namespace itk
   ::ApplyMatrix (const MatrixType& R) const
   {
     Self res;
-    res.SetVnlMatrix ( this->ApplyMatrix (R.GetVnlMatrix() ) );
+    res.SetVnlMatrix ( this->ApplyMatrix (R.GetVnlMatrix().as_ref()).as_ref());
     return res;
   }
 


### PR DESCRIPTION
Remove huge amount of warnings in TTK which made the reading of the compilation more complicated, and the compilation slower.

Three warnings are still unsolved, but this PR solves a lot of them.

:m: